### PR TITLE
PdoStorage: Fix for userid cannot  be null

### DIFF
--- a/lib/Pheal/Cache/PdoStorage.php
+++ b/lib/Pheal/Cache/PdoStorage.php
@@ -155,6 +155,12 @@ class PdoStorage implements CanCache
         $statement = $this->statements['load'];
         /* @var $statement \PDOStatement */
 
+        if ($userid === null) {
+            // Fix for null value userids
+            // e. g. for global calls to /eve/
+            $userid = 0;
+        }
+
         try {
             $statement->execute(
                 array(
@@ -221,6 +227,13 @@ class PdoStorage implements CanCache
 
         $deleteStatement = $this->statements['delete'];
         /* @var $deleteStatement \PDOStatement */
+
+        if ($userid === null) {
+            // Fix for null value userids
+            // e. g. for global calls to /eve/
+            $userid = 0;
+        }
+
         try {
             $deleteStatement->execute(
                 array(


### PR DESCRIPTION
For calls against the EVE scope there is no need for an API Key. In this case "userid" is null, which is currently not properly supported in the PdoStorage and the example cache table.

I fixed this problem by using "0" as userid in this case. Its a value that doesn't break the cache and won't be used by the API keys at all.
