### PR TITLE
add missing option parameter to set call on predis cache

### DIFF
--- a/lib/Pheal/Cache/PredisStorage.php
+++ b/lib/Pheal/Cache/PredisStorage.php
@@ -91,7 +91,7 @@ class PredisStorage implements CanCache
         $key = $this->getKey($userid, $apikey, $scope, $name, $args);
         $timeout = $this->getTimeout($xml);
 
-        return $this->redis->set($key, $xml, $timeout);
+        return $this->redis->set($key, $xml, 'ex', $timeout);
     }
 
     /**


### PR DESCRIPTION
I derped fairly hard on this. Sorry it took me a while to fix:

3rd parameter is used to specify options for the timeout, with the number of seconds being the 4th parameter.

'ex' tells redis to interpret the timeout value as a number of seconds.