### PR TITLE
Bump Guzzle version to 6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.4.0",
         "psr/log": "1.0.0",
-        "guzzlehttp/guzzle": "~6.0.2"
+        "guzzlehttp/guzzle": "~6.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7.7"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "326204365b62cf15d764eda4bafe3035",
+    "hash": "c986b2799cbbe4629fa09f89ce453544",
+    "content-hash": "d97858fcc64fc4988d5ae66e7c577330",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.0.2",
+            "version": "6.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "a8dfeff00eb84616a17fea7a4d72af35e750410f"
+                "reference": "c6851d6e48f63b69357cbfa55bca116448140e0c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/a8dfeff00eb84616a17fea7a4d72af35e750410f",
-                "reference": "a8dfeff00eb84616a17fea7a4d72af35e750410f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/c6851d6e48f63b69357cbfa55bca116448140e0c",
+                "reference": "c6851d6e48f63b69357cbfa55bca116448140e0c",
                 "shasum": ""
             },
             "require": {
@@ -33,7 +34,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -66,7 +67,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2015-07-04 20:09:24"
+            "time": "2015-11-23 00:47:50"
         },
         {
             "name": "guzzlehttp/promises",


### PR DESCRIPTION
Having trouble with a project that requires Guzzle 6.1. Since the unit test passes, I figured the upgrade to ~6.1 should be ok.