### PR TITLE
Fix Guzzle fetcher for both GET & POST HTTP Verbs

### DIFF
--- a/lib/Pheal/Fetcher/Guzzle.php
+++ b/lib/Pheal/Fetcher/Guzzle.php
@@ -48,6 +48,11 @@ class Guzzle implements CanFetch
      */
     public function fetch($url, $options)
     {
+
+        $request_type = $this->config->http_post === true ?
+            'form_params' : 'query';
+        $options = [$request_type => $options];
+
         try {
             $response = $this->client->request(
                 $this->config->http_post === true ? 'POST' : 'GET',


### PR DESCRIPTION
As the title says, currently, the Guzzle fetcher does not play nice with the HTTP GET method. This PR overrides the `$options` argument in `fetch()` so that either the [query](http://docs.guzzlephp.org/en/latest/request-options.html#query) array (for GET) or or the [form_params](http://docs.guzzlephp.org/en/latest/request-options.html#form-params) array (for POST) is appropriately set.

Not setting these arrays will result in requests to the EVE API failing that require *any* arguments. A sample error experienced can be seen below:

```
Client error: `GET https://api.eveonline.com/account/APIKeyInfo.xml.aspx` resulted in a `400 Bad Request` response:
```

With the response XML for the call containing:

```xml
<?xml version='1.0' encoding='UTF-8'?>
<eveapi version="2">
  <currentTime>2015-12-11 17:31:59</currentTime>
  <error code="106">Must provide userID or keyID parameter for authentication.
  <cachedUntil>2015-12-12 05:31:59</cachedUntil>
</eveapi>
```