### PR TITLE
Loosen the dependency to psr/log from a specific version to sem ver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
             "email": "ppetermann80@googlemail.com",
             "homepage": "http://devedge.eu"
         },
-        {   
+        {
             "name": "Wollari",
             "homepage": "http://evemaps.dotlan.net/"
         }
     ],
     "require": {
         "php": ">=5.4.0",
-        "psr/log": "1.0.0",
+        "psr/log": "~1.0.0",
         "guzzlehttp/guzzle": "~6.1"
     },
     "require-dev": {


### PR DESCRIPTION
The version of "psr/log" requested was very specific (1.0.0) and does not allow to use newer patch-releases.

A new patch-release 1.0.1 was released that a few other packages depend on and phealng stops me from updating them.
